### PR TITLE
3-Way Matcher Fusion 적용 (MegaDescriptor + ALIKED + LoFTR)

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,8 @@ import os
 # 동연 로컬 경로
 # ROOT = r"C:\Users\user\Desktop\kimdongyeon\CV_proj\bitamin_cv_proj\animal-clef-2025"
 # 보희 로컬 경로
-
+# # 보희 로컬 경로
+ROOT = r"C:\Users\family\Desktop\보희\대내외활동\대외\BIAamin\25 학기세션\컴퓨터비전 프로젝트\kaggle\animal-clef-2025"
 # 수아 로컬 경로
 
 # 채연 로컬 경로

--- a/config.py
+++ b/config.py
@@ -7,8 +7,9 @@ import os
 # 동연 로컬 경로
 # ROOT = r"C:\Users\user\Desktop\kimdongyeon\CV_proj\bitamin_cv_proj\animal-clef-2025"
 # 보희 로컬 경로
-# # 보희 로컬 경로
-ROOT = r"C:\Users\family\Desktop\보희\대내외활동\대외\BIAamin\25 학기세션\컴퓨터비전 프로젝트\kaggle\animal-clef-2025"
+# ROOT = "/kaggle/input/animal-clef-2025"  # 읽기 전용 데이터
+# PROCESSED_DIR = "/kaggle/working/processed"  # 전처리된 이미지 저장용
+
 # 수아 로컬 경로
 
 # 채연 로컬 경로

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ def main():
     matcher_loftr = build_loftr(transform=transforms_aliked, device=DEVICE)
 
     # 4. Build fusion model and apply calibration
-    fusion = build_wildfusion(matcher_loftr, matcher_mega, dataset_calib, dataset_calib)
+    fusion = build_wildfusion(matcher_aliked, matcher_loftr, matcher_mega, dataset_calib, dataset_calib)
 
     # 5. Compute predictions per query group (by dataset) but compare against full DB
     predictions_all = []

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ import kornia
 from PIL import Image
 
 # 📁 경로 설정 (ROOT는 config.py에서 import됨)
-PROCESSED_DIR = os.path.join(ROOT, "processed")
+from config import PROCESSED_DIR
 METADATA_PATH = os.path.join(ROOT, "metadata.csv")
 
 # ✨ CLAHE 적용 함수

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import torchvision.transforms.functional as TF
 import torchvision.transforms as T
 import kornia
 from PIL import Image
+from tqdm import tqdm
 
 # 📁 경로 설정 (ROOT는 config.py에서 import됨)
 from config import PROCESSED_DIR
@@ -79,7 +80,7 @@ def run_preprocessing():
         os.makedirs(PROCESSED_DIR)
 
     metadata = pd.read_csv(METADATA_PATH)
-    for idx, row in metadata.iterrows():
+    for idx, row in tqdm(metadata.iterrows(), total=len(metadata), desc="🔄 전처리 진행 중"):
         img_path = os.path.join(ROOT, row["path"])
         species_name = row["dataset"]
         image_id = row["image_id"]
@@ -93,9 +94,6 @@ def run_preprocessing():
         processed_img = preprocess_image(img, species_name)
         save_path = os.path.join(PROCESSED_DIR, f"{image_id}.png")
         processed_img.save(save_path)
-
-        if idx % 500 == 0:
-            print(f"✅ Processed {idx}/{len(metadata)} images")
 
 
 def main():

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from config import ROOT, MEGAD_NAME, DEVICE, THRESHOLD
 from src.transforms import transform, transforms_aliked
 from src.utils import create_sample_submission
 from src.dataset import load_datasets
-from src.matcher import build_megadescriptor, build_aliked
+from src.matcher import build_megadescriptor, build_aliked, build_loftr
 from src.fusion import build_wildfusion
 
 import timm
@@ -110,9 +110,10 @@ def main():
     # 3. Build matchers
     matcher_mega = build_megadescriptor(model=model, transform=transform, device=DEVICE)
     matcher_aliked = build_aliked(transform=transforms_aliked, device=DEVICE)
+    matcher_loftr = build_loftr(transform=transforms_aliked, device=DEVICE)
 
     # 4. Build fusion model and apply calibration
-    fusion = build_wildfusion(matcher_aliked, matcher_mega, dataset_calib, dataset_calib)
+    fusion = build_wildfusion(matcher_loftr, matcher_mega, dataset_calib, dataset_calib)
 
     # 5. Compute predictions per query group (by dataset) but compare against full DB
     predictions_all = []

--- a/src/fusion.py
+++ b/src/fusion.py
@@ -6,7 +6,8 @@ WildFusion 객체 생성 + calibration 수행
 def build_wildfusion(matcher_aliked, matcher_mega, calibration_query, calibration_db):
     fusion = WildFusion(
         calibrated_pipelines=[matcher_aliked, matcher_mega],
-        priority_pipeline=matcher_mega
+        priority_pipeline=matcher_mega,
+        weights=[0.3, 0.7]  # ALIKED, MEGAD 각각 가중치
     )
     fusion.fit_calibration(calibration_query, calibration_db)
     return fusion

--- a/src/fusion.py
+++ b/src/fusion.py
@@ -3,7 +3,7 @@ from wildlife_tools.similarity.wildfusion import WildFusion
 '''
 WildFusion 객체 생성 + calibration 수행
 '''
-def build_wildfusion(matcher_aliked, matcher_mega, calibration_query, calibration_db):
+def build_wildfusion(matcher_aliked, matcher_loftr, matcher_mega, calibration_query, calibration_db):
     fusion = WildFusion(
         calibrated_pipelines=[matcher_aliked, matcher_mega],
         priority_pipeline=matcher_mega,

--- a/src/fusion.py
+++ b/src/fusion.py
@@ -5,9 +5,9 @@ WildFusion 객체 생성 + calibration 수행
 '''
 def build_wildfusion(matcher_aliked, matcher_loftr, matcher_mega, calibration_query, calibration_db):
     fusion = WildFusion(
-        calibrated_pipelines=[matcher_aliked, matcher_mega],
+        calibrated_pipelines=[matcher_aliked, matcher_loftr, matcher_mega],
         priority_pipeline=matcher_mega,
-        weights=[0.2, 0.3, 0.5]  # 가중치 조정 필요
+        weights=[0.2, 0.3, 0.5]  # ALIKED, LoFTR, MEGA 순서
     )
     fusion.fit_calibration(calibration_query, calibration_db)
     return fusion

--- a/src/fusion.py
+++ b/src/fusion.py
@@ -7,7 +7,7 @@ def build_wildfusion(matcher_aliked, matcher_mega, calibration_query, calibratio
     fusion = WildFusion(
         calibrated_pipelines=[matcher_aliked, matcher_mega],
         priority_pipeline=matcher_mega,
-        weights=[0.3, 0.7]  # ALIKED, MEGAD 각각 가중치
+        weights=[0.2, 0.3, 0.5]  # 가중치 조정 필요
     )
     fusion.fit_calibration(calibration_query, calibration_db)
     return fusion

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -4,6 +4,7 @@ from wildlife_tools.similarity.wildfusion import SimilarityPipeline
 from wildlife_tools.features import DeepFeatures
 from wildlife_tools.features.local import AlikedExtractor
 from wildlife_tools.similarity.calibration import IsotonicCalibration
+from wildlife_tools.similarity.pairwise.loftr import MatchLoFTR
 
 '''
 MegaDescriptor, ALIKED matcher 각각 생성 + return
@@ -20,6 +21,14 @@ def build_aliked(transform, device='cuda', batch_size=16):
     return SimilarityPipeline(
         matcher=MatchLightGlue(features='aliked', device=device, batch_size=batch_size),
         extractor=AlikedExtractor(),
+        transform=transform,
+        calibration=IsotonicCalibration()
+    )
+    
+def build_loftr(transform, device='cuda', batch_size=16):
+    return SimilarityPipeline(
+        matcher=MatchLoFTR(device=device, batch_size=batch_size),
+        extractor=None,  # LoFTR은 추출기 불필요
         transform=transform,
         calibration=IsotonicCalibration()
     )


### PR DESCRIPTION
- 기존: MegaDescriptor와 ALIKED 두 개의 matcher만 사용
- 수정: LoFTR matcher 추가하여 총 3개 matcher를 WildFusion에 통합
- 각각의 matcher는 build_megadescriptor(), build_aliked(), build_loftr()로 생성하고, fusion.py에서 함께 조합
- 가중치는 [0.2, 0.3, 0.5]로 설정하여 ALIKED, LoFTR, MegaDescriptor 순으로 반영